### PR TITLE
Naver Map 관련 수정

### DIFF
--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -35,6 +35,7 @@ const NaverMap: React.FC<NaverMapProps> = ({ placeList, setPartner }) => {
         style: naver.maps.ZoomControlStyle.SMALL,
         position: naver.maps.Position.TOP_RIGHT,
       },
+      scrollWheel: false,
     };
 
     const map = new naver.maps.Map(container, mapOptions);

--- a/src/pages/MainPage/style.ts
+++ b/src/pages/MainPage/style.ts
@@ -162,7 +162,7 @@ export const FloatingBar = styled.div`
   height: 80px;
   position: fixed;
   bottom: 0;
-  z-index: 10;
+  z-index: 100;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
- 네이버 로고와 zoom 컨트롤러가 Floating Bar보다 위에 오는 현상 수정 (네이버맵의 z-index는 100)

- 랜딩페이지 스크롤 내리다 지도 확대/축소되는 부분 방지